### PR TITLE
Signal input mute state across Realtime and Conference

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,20 @@ receive an explicit error targeted to the sending participant. The old
 `hermes-chat` and raw conversation `agent:*` streams are not part of the new
 contract.
 
+Hermes adds one namespaced input-state extension because the portable OpenAI
+Realtime event set has no microphone mute/unmute signal:
+
+```json
+{"type":"hermes.input_audio.state","muted":true}
+```
+
+Direct WebRTC clients send it on `oai-events`. Conference clients send the
+same envelope reliably on `conference.extensions`. The server responds on the
+same transport with `hermes.input_audio.state_updated`. Muting immediately
+finalizes any active utterance and then ignores media frames; unmuting clears
+stale audio and recalibrates the participant's adaptive noise gate. Clients
+that omit this optional extension retain energy-based endpointing.
+
 ### Conference extensions
 
 Portable tool discovery uses `conference.tools`, exactly as it does with
@@ -265,6 +279,10 @@ Reliable JSON payloads on `conference.extensions`:
 
 // this speaker is done talking; close the utterance and dispatch it now (0.4.0+)
 {"type": "conference.control", "action": "end-of-turn"}
+
+// participant-scoped mute boundary and VAD recalibration
+{"type": "hermes.input_audio.state", "muted": true}
+{"type": "hermes.input_audio.state", "muted": false}
 ```
 
 `end-of-turn` is for clients that endpoint locally. Without it the adapter can

--- a/hermes_livekit/adapter.py
+++ b/hermes_livekit/adapter.py
@@ -1053,8 +1053,8 @@ class LiveKitAdapter(BasePlatformAdapter):
             task.cancel()
         self._audio_buffers.pop(identity, None)
         self._last_audio_time.pop(identity, None)
-        self._audio_gates.pop(identity, None)
-        self._muted_inputs.discard(identity)
+        getattr(self, "_audio_gates", {}).pop(identity, None)
+        getattr(self, "_muted_inputs", set()).discard(identity)
         self._speaking_participants.discard(identity)
 
     # -- Audio capture and processing ---------------------------------------

--- a/hermes_livekit/adapter.py
+++ b/hermes_livekit/adapter.py
@@ -67,7 +67,11 @@ from gateway.platforms.base import (
 )
 from gateway.session import build_session_key
 
-from .realtime_protocol import RealtimeProtocol
+from .realtime_protocol import (
+    HERMES_INPUT_AUDIO_STATE,
+    HERMES_INPUT_AUDIO_STATE_UPDATED,
+    RealtimeProtocol,
+)
 from .tool_result_protocol import (
     DRAIN_TIMEOUT_SEC,
     REFERENCE_TYPE,
@@ -91,6 +95,7 @@ from .tool_safety import (
     valid_participant_identity,
     valid_tool_name,
 )
+from .vad import AdaptiveRmsGate
 
 # Use the ``gateway.platforms.livekit`` namespace rather than ``__name__``.
 # Hermes core's gateway.log handler installs a component filter that only
@@ -248,6 +253,8 @@ class LiveKitAdapter(BasePlatformAdapter):
         self._audio_buffers: Dict[str, bytearray] = {}
         self._last_audio_time: Dict[str, float] = {}
         self._audio_streams: Dict[str, asyncio.Task] = {}
+        self._audio_gates: Dict[str, AdaptiveRmsGate] = {}
+        self._muted_inputs: set[str] = set()
 
         # Pause audio capture during TTS playback
         self._paused = False
@@ -646,6 +653,8 @@ class LiveKitAdapter(BasePlatformAdapter):
         self._local_track = None
         self._audio_buffers.clear()
         self._last_audio_time.clear()
+        self._audio_gates.clear()
+        self._muted_inputs.clear()
         self._speaking_participants.clear()
 
         # Unlink any frame files that were captured but never dispatched
@@ -752,6 +761,10 @@ class LiveKitAdapter(BasePlatformAdapter):
         if track.kind == rtc.TrackKind.KIND_AUDIO:
             logger.info("[%s] Audio track subscribed: %s", self.name, identity)
             self._audio_buffers[identity] = bytearray()
+            self._audio_gates[identity] = AdaptiveRmsGate(
+                calibration_frames=max(1, round(0.4 / POLL_INTERVAL)),
+                minimum_floor=RMS_SILENCE_FLOOR,
+            )
             # Deliberately do NOT seed _last_audio_time here. _check_silence_loop
             # sets it on the first chunk above RMS_SILENCE_FLOOR, and treats a
             # missing entry as "this participant has never spoken" — discarding
@@ -891,6 +904,8 @@ class LiveKitAdapter(BasePlatformAdapter):
         self._audio_streams.clear()
         self._audio_buffers.clear()
         self._last_audio_time.clear()
+        self._audio_gates.clear()
+        self._muted_inputs.clear()
         self._speaking_participants.clear()
 
         # Clients will be gone after we drop the room — clear their tools.
@@ -1038,6 +1053,8 @@ class LiveKitAdapter(BasePlatformAdapter):
             task.cancel()
         self._audio_buffers.pop(identity, None)
         self._last_audio_time.pop(identity, None)
+        self._audio_gates.pop(identity, None)
+        self._muted_inputs.discard(identity)
         self._speaking_participants.discard(identity)
 
     # -- Audio capture and processing ---------------------------------------
@@ -1056,7 +1073,7 @@ class LiveKitAdapter(BasePlatformAdapter):
         """
         try:
             async for event in stream:
-                if self._paused:
+                if self._paused or identity in self._muted_inputs:
                     continue
                 if identity not in self._audio_buffers:
                     break
@@ -1104,7 +1121,29 @@ class LiveKitAdapter(BasePlatformAdapter):
                     tail = bytes(buf[-bytes_per_tick:]) if buf_len >= bytes_per_tick else bytes(buf)
                     rms = _compute_rms(tail)
 
-                    if rms > RMS_SILENCE_FLOOR:
+                    gate = self._audio_gates.get(identity)
+                    if gate is None:
+                        gate = AdaptiveRmsGate(
+                            calibration_frames=max(1, round(0.4 / POLL_INTERVAL)),
+                            minimum_floor=RMS_SILENCE_FLOOR,
+                        )
+                        self._audio_gates[identity] = gate
+                    if not gate.ready:
+                        if not gate.calibrate(rms):
+                            continue
+                        logger.info(
+                            "[%s] adaptive VAD for %s: noise_rms=%.1f start=%.1f stop=%.1f",
+                            self.name,
+                            identity,
+                            gate.noise_rms,
+                            gate.start_threshold,
+                            gate.stop_threshold,
+                        )
+
+                    if gate.is_speech(
+                        rms,
+                        speaking=identity in self._speaking_participants,
+                    ):
                         # Active speech — update timestamp
                         self._last_audio_time[identity] = time.monotonic()
                         # Emit listening-start on first loud chunk of an utterance
@@ -1322,6 +1361,10 @@ class LiveKitAdapter(BasePlatformAdapter):
                 "conference.capture_frame": lambda: self._capture_next_frame(participant_identity),
                 "conference.message": lambda: self._handle_client_message(msg, participant_identity),
                 "conference.control": lambda: self._handle_client_control(msg, participant_identity),
+                HERMES_INPUT_AUDIO_STATE: lambda: self._handle_input_audio_state(
+                    msg,
+                    participant_identity,
+                ),
             }
         handler = handlers.get(msg_type)
         if handler is None:
@@ -1483,6 +1526,58 @@ class LiveKitAdapter(BasePlatformAdapter):
             logger.info("[%s] resumed by client %s", self.name, identity)
         else:
             logger.debug("[%s] unknown client:control action %r", self.name, action)
+
+    async def _handle_input_audio_state(
+        self,
+        msg: Dict[str, Any],
+        identity: str,
+    ) -> None:
+        """Apply the shared Hermes mute extension to one participant."""
+        muted = msg.get("muted")
+        if not isinstance(muted, bool):
+            logger.debug("[%s] invalid input audio state from %s", self.name, identity)
+            return
+        await self._set_input_audio_state(identity, muted)
+        await self._publish_typed(
+            {
+                "type": HERMES_INPUT_AUDIO_STATE_UPDATED,
+                "muted": muted,
+            },
+            identity=identity,
+            topic=self.DATA_CHANNEL_EXTENSIONS_TOPIC,
+        )
+
+    async def _set_input_audio_state(self, identity: str, muted: bool) -> None:
+        muted_inputs = getattr(self, "_muted_inputs", None)
+        if muted_inputs is None:
+            muted_inputs = self._muted_inputs = set()
+        if muted:
+            muted_inputs.add(identity)
+            buf = self._audio_buffers.get(identity)
+            if (
+                identity in self._speaking_participants
+                and self._flush_utterance(identity, len(buf) if buf else 0)
+            ):
+                logger.info("[%s] input muted by %s; utterance finalized", self.name, identity)
+            else:
+                self._audio_buffers[identity] = bytearray()
+                self._last_audio_time.pop(identity, None)
+                self._speaking_participants.discard(identity)
+                logger.info("[%s] input muted by %s", self.name, identity)
+            return
+
+        muted_inputs.discard(identity)
+        self._audio_buffers[identity] = bytearray()
+        self._last_audio_time.pop(identity, None)
+        self._speaking_participants.discard(identity)
+        audio_gates = getattr(self, "_audio_gates", None)
+        if audio_gates is None:
+            audio_gates = self._audio_gates = {}
+        audio_gates[identity] = AdaptiveRmsGate(
+            calibration_frames=max(1, round(0.4 / POLL_INTERVAL)),
+            minimum_floor=RMS_SILENCE_FLOOR,
+        )
+        logger.info("[%s] input unmuted by %s; adaptive VAD reset", self.name, identity)
 
     # -- Remote tools (client-registered) -----------------------------------
 
@@ -1696,6 +1791,8 @@ class LiveKitAdapter(BasePlatformAdapter):
         getattr(self, "_video_streams", {}).clear()
         getattr(self, "_audio_buffers", {}).clear()
         getattr(self, "_last_audio_time", {}).clear()
+        getattr(self, "_audio_gates", {}).clear()
+        getattr(self, "_muted_inputs", set()).clear()
         getattr(self, "_speaking_participants", set()).clear()
         self._audio_source = None
         self._local_track = None

--- a/hermes_livekit/realtime_protocol.py
+++ b/hermes_livekit/realtime_protocol.py
@@ -22,6 +22,9 @@ DEFAULT_TOOL_TIMEOUT_SECONDS = 30.0
 Publish = Callable[[dict[str, Any], Optional[str]], Awaitable[bool]]
 ClientCallback = Callable[[str], Awaitable[None] | None]
 TextCallback = Callable[[str, str], Awaitable[None] | None]
+InputAudioStateCallback = Callable[[bool, str], Awaitable[None] | None]
+HERMES_INPUT_AUDIO_STATE = "hermes.input_audio.state"
+HERMES_INPUT_AUDIO_STATE_UPDATED = "hermes.input_audio.state_updated"
 
 
 async def _call(callback: Callable[..., Any] | None, *args: Any) -> bool:
@@ -46,6 +49,7 @@ class RealtimeProtocol:
         on_text_input: TextCallback | None = None,
         on_response_requested: ClientCallback | None = None,
         on_response_cancelled: ClientCallback | None = None,
+        on_input_audio_state: InputAudioStateCallback | None = None,
         instructions: str = "",
         tool_choice: str = "auto",
         tool_timeout_seconds: float = DEFAULT_TOOL_TIMEOUT_SECONDS,
@@ -57,6 +61,7 @@ class RealtimeProtocol:
         self._on_text_input = on_text_input
         self._on_response_requested = on_response_requested
         self._on_response_cancelled = on_response_cancelled
+        self._on_input_audio_state = on_input_audio_state
         self.instructions = instructions
         self.tool_choice = tool_choice
         self._tool_timeout_seconds = tool_timeout_seconds
@@ -133,6 +138,8 @@ class RealtimeProtocol:
             await self._accept_response_create(identity, event_id)
         elif event_type == "response.cancel":
             await self._accept_response_cancel(identity, event_id)
+        elif event_type == HERMES_INPUT_AUDIO_STATE:
+            await self._accept_input_audio_state(event, identity, event_id)
         else:
             label = event_type if isinstance(event_type, str) else "unknown"
             await self._error(
@@ -142,6 +149,39 @@ class RealtimeProtocol:
                 param="type",
                 triggering_event_id=event_id,
             )
+
+    async def _accept_input_audio_state(
+        self,
+        event: dict[str, Any],
+        identity: str,
+        event_id: str | None,
+    ) -> None:
+        muted = event.get("muted")
+        if not isinstance(muted, bool):
+            await self._error(
+                "invalid_input_audio_state",
+                "muted must be a boolean",
+                identity,
+                param="muted",
+                triggering_event_id=event_id,
+            )
+            return
+        if not await _call(self._on_input_audio_state, muted, identity):
+            await self._error(
+                "unsupported_client_event",
+                "Input audio state is not supported by this transport",
+                identity,
+                param="type",
+                triggering_event_id=event_id,
+            )
+            return
+        await self._emit(
+            {
+                "type": HERMES_INPUT_AUDIO_STATE_UPDATED,
+                "muted": muted,
+            },
+            recipient=identity,
+        )
 
     def _session_snapshot(self) -> dict[str, Any]:
         return {

--- a/hermes_livekit/realtime_webrtc.py
+++ b/hermes_livekit/realtime_webrtc.py
@@ -66,6 +66,7 @@ from .adapter import (
 )
 from .realtime_protocol import MAX_INSTRUCTIONS_BYTES, RealtimeProtocol
 from .direct_tools import DirectToolBridge, DirectToolError, parse_direct_tools
+from .vad import AdaptiveRmsGate
 
 
 logger = logging.getLogger("gateway.platforms.realtime")
@@ -74,15 +75,6 @@ MAX_SDP_BYTES = 256 * 1024
 MAX_SESSION_BYTES = 512 * 1024
 DEFAULT_MAX_CALLS = 8
 DEFAULT_MAX_CALL_SECONDS = 2 * 60 * 60
-VAD_CALIBRATION_FRAMES = 20
-VAD_NOISE_CEILING = 300.0
-VAD_MIN_START_THRESHOLD = 300.0
-VAD_MIN_STOP_THRESHOLD = 220.0
-VAD_START_RATIO = 2.2
-VAD_START_MARGIN = 100.0
-VAD_STOP_RATIO = 1.5
-VAD_STOP_MARGIN = 60.0
-VAD_NOISE_ALPHA = 0.02
 PROXY_PRINCIPAL_HEADER = "X-Kortexa-Internal-Principal"
 PROXY_CALL_HEADER = "X-Kortexa-Internal-Call-Id"
 PROXY_TIMESTAMP_HEADER = "X-Kortexa-Internal-Timestamp"
@@ -242,65 +234,6 @@ class QueuedAudioTrack(MediaStreamTrack):
 
 
 @dataclass
-class AdaptiveRmsGate:
-    """Small adaptive energy gate for continuously noisy kiosk microphones."""
-
-    noise_rms: float | None = None
-    calibration: list[float] = field(default_factory=list)
-
-    @property
-    def ready(self) -> bool:
-        return self.noise_rms is not None
-
-    @property
-    def start_threshold(self) -> float:
-        noise = self.noise_rms or float(RMS_SILENCE_FLOOR)
-        return max(
-            VAD_MIN_START_THRESHOLD,
-            noise * VAD_START_RATIO,
-            noise + VAD_START_MARGIN,
-        )
-
-    @property
-    def stop_threshold(self) -> float:
-        noise = self.noise_rms or float(RMS_SILENCE_FLOOR)
-        return max(
-            VAD_MIN_STOP_THRESHOLD,
-            noise * VAD_STOP_RATIO,
-            noise + VAD_STOP_MARGIN,
-        )
-
-    def calibrate(self, rms: float) -> bool:
-        if self.ready:
-            return True
-        self.calibration.append(rms)
-        if len(self.calibration) < VAD_CALIBRATION_FRAMES:
-            return False
-
-        # Use the quieter half so somebody beginning to speak during the
-        # short calibration window does not become the learned noise floor.
-        ordered = sorted(self.calibration)
-        quiet = ordered[: max(1, len(ordered) // 2)]
-        measured = sum(quiet) / len(quiet)
-        self.noise_rms = min(VAD_NOISE_CEILING, max(1.0, measured))
-        self.calibration.clear()
-        return True
-
-    def is_speech(self, rms: float, *, speaking: bool) -> bool:
-        threshold = self.stop_threshold if speaking else self.start_threshold
-        speech = rms > threshold
-        if not speaking and not speech and self.noise_rms is not None:
-            # Follow slow changes such as a fan ramping up, but never learn a
-            # speech frame or allow an outlier to raise the floor indefinitely.
-            observed = min(rms, VAD_NOISE_CEILING)
-            self.noise_rms = (
-                (1.0 - VAD_NOISE_ALPHA) * self.noise_rms
-                + VAD_NOISE_ALPHA * observed
-            )
-        return speech
-
-
-@dataclass
 class RealtimeCall:
     adapter: "RealtimeWebRTCAdapter"
     call_id: str
@@ -315,6 +248,7 @@ class RealtimeCall:
     last_speech_at: float | None = None
     speaking: bool = False
     paused: bool = False
+    input_muted: bool = False
     tts_completed: bool = False
     closed: bool = False
     vad: AdaptiveRmsGate = field(default_factory=AdaptiveRmsGate)
@@ -359,7 +293,7 @@ class RealtimeCall:
         try:
             while not self.closed:
                 frame = await track.recv()
-                if self.paused:
+                if self.paused or self.input_muted:
                     continue
                 for converted in resampler.resample(frame):
                     size = converted.samples * NUM_CHANNELS * 2
@@ -420,6 +354,31 @@ class RealtimeCall:
         duration = len(pcm) / (SAMPLE_RATE * NUM_CHANNELS * 2)
         if duration >= MIN_SPEECH_DURATION:
             self.spawn(self.adapter.process_voice(self, pcm))
+
+    async def set_input_audio_state(self, muted: bool) -> None:
+        """Apply an explicit client mute boundary to capture and endpointing."""
+        if muted == self.input_muted:
+            return
+        self.input_muted = muted
+        if muted:
+            if self.speaking and self.audio_buffer:
+                await self.finish_utterance()
+            else:
+                self.audio_buffer.clear()
+                self.last_speech_at = None
+                self.speaking = False
+            self.vad_calibration_pcm.clear()
+            logger.info("[%s] input muted by client", self.call_id)
+            return
+
+        # Calibrate against the real microphone after it replaces any muted
+        # placeholder track. This avoids learning digital zero as room noise.
+        self.audio_buffer.clear()
+        self.last_speech_at = None
+        self.speaking = False
+        self.vad = AdaptiveRmsGate(minimum_floor=RMS_SILENCE_FLOOR)
+        self.vad_calibration_pcm.clear()
+        logger.info("[%s] input unmuted; adaptive VAD reset", self.call_id)
 
     async def close(self) -> None:
         if self.closed:
@@ -669,6 +628,7 @@ class RealtimeWebRTCAdapter(BasePlatformAdapter):
                     "Follow the session instructions and respond now.",
                 ),
                 on_response_cancelled=lambda _identity: self.cancel_call_response(call),
+                on_input_audio_state=lambda muted, _identity: call.set_input_audio_state(muted),
             )
             call = RealtimeCall(
                 self,

--- a/hermes_livekit/vad.py
+++ b/hermes_livekit/vad.py
@@ -1,0 +1,76 @@
+"""Transport-neutral adaptive energy gate for voice activity detection."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+VAD_NOISE_CEILING = 300.0
+VAD_MIN_START_THRESHOLD = 300.0
+VAD_MIN_STOP_THRESHOLD = 220.0
+VAD_START_RATIO = 2.2
+VAD_START_MARGIN = 100.0
+VAD_STOP_RATIO = 1.5
+VAD_STOP_MARGIN = 60.0
+VAD_NOISE_ALPHA = 0.02
+
+
+@dataclass
+class AdaptiveRmsGate:
+    """Adaptive RMS gate that tolerates continuous fan and room noise."""
+
+    calibration_frames: int = 20
+    minimum_floor: float = 50.0
+    noise_rms: float | None = None
+    calibration: list[float] = field(default_factory=list)
+
+    @property
+    def ready(self) -> bool:
+        return self.noise_rms is not None
+
+    @property
+    def start_threshold(self) -> float:
+        noise = self.noise_rms or self.minimum_floor
+        return max(
+            VAD_MIN_START_THRESHOLD,
+            noise * VAD_START_RATIO,
+            noise + VAD_START_MARGIN,
+        )
+
+    @property
+    def stop_threshold(self) -> float:
+        noise = self.noise_rms or self.minimum_floor
+        return max(
+            VAD_MIN_STOP_THRESHOLD,
+            noise * VAD_STOP_RATIO,
+            noise + VAD_STOP_MARGIN,
+        )
+
+    def calibrate(self, rms: float) -> bool:
+        if self.ready:
+            return True
+        self.calibration.append(rms)
+        if len(self.calibration) < self.calibration_frames:
+            return False
+
+        # Use the quieter half so somebody beginning to speak during the
+        # short calibration window does not become the learned noise floor.
+        ordered = sorted(self.calibration)
+        quiet = ordered[: max(1, len(ordered) // 2)]
+        measured = sum(quiet) / len(quiet)
+        self.noise_rms = min(VAD_NOISE_CEILING, max(1.0, measured))
+        self.calibration.clear()
+        return True
+
+    def is_speech(self, rms: float, *, speaking: bool) -> bool:
+        threshold = self.stop_threshold if speaking else self.start_threshold
+        speech = rms > threshold
+        if not speaking and not speech and self.noise_rms is not None:
+            # Follow slow changes such as a fan ramping up, but never learn a
+            # speech frame or allow an outlier to raise the floor indefinitely.
+            observed = min(rms, VAD_NOISE_CEILING)
+            self.noise_rms = (
+                (1.0 - VAD_NOISE_ALPHA) * self.noise_rms
+                + VAD_NOISE_ALPHA * observed
+            )
+        return speech

--- a/tests/test_realtime_conference.py
+++ b/tests/test_realtime_conference.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -28,8 +29,48 @@ def conference_adapter() -> tuple[LiveKitAdapter, LocalParticipant]:
     )
     adapter._audio_source = None
     adapter._paused = False
+    adapter._audio_buffers = {"client-a": bytearray()}
+    adapter._last_audio_time = {}
+    adapter._speaking_participants = set()
+    adapter._audio_gates = {}
+    adapter._muted_inputs = set()
     adapter._realtime_protocol = adapter._new_realtime_protocol()
     return adapter, local
+
+
+@pytest.mark.asyncio
+async def test_conference_input_audio_state_is_scoped_and_acknowledged() -> None:
+    adapter, local = conference_adapter()
+    adapter._process_voice_input = AsyncMock()
+    adapter._audio_buffers["client-a"].extend(b"\x00\x00" * 48_000)
+    adapter._speaking_participants.add("client-a")
+
+    await adapter._handle_input_audio_state(
+        {"type": "hermes.input_audio.state", "muted": True},
+        "client-a",
+    )
+    assert "client-a" in adapter._muted_inputs
+    assert adapter._audio_buffers["client-a"] == b""
+    acknowledgement = next(
+        (message, options)
+        for message, options in local.messages
+        if message["type"] == "hermes.input_audio.state_updated"
+    )
+    assert acknowledgement[0] == {
+        "type": "hermes.input_audio.state_updated",
+        "muted": True,
+    }
+    assert acknowledgement[1]["topic"] == adapter.DATA_CHANNEL_EXTENSIONS_TOPIC
+    assert acknowledgement[1]["destination_identities"] == ["client-a"]
+    await asyncio.sleep(0)
+    adapter._process_voice_input.assert_awaited_once()
+
+    await adapter._handle_input_audio_state(
+        {"type": "hermes.input_audio.state", "muted": False},
+        "client-a",
+    )
+    assert "client-a" not in adapter._muted_inputs
+    assert adapter._audio_gates["client-a"].ready is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_realtime_protocol.py
+++ b/tests/test_realtime_protocol.py
@@ -26,6 +26,40 @@ def protocol_fixture(**callbacks):
 
 
 @pytest.mark.asyncio
+async def test_routes_namespaced_input_audio_state_and_acknowledges_it() -> None:
+    states: list[tuple[bool, str]] = []
+
+    async def on_state(muted: bool, identity: str) -> None:
+        states.append((muted, identity))
+
+    protocol, sent = protocol_fixture(on_input_audio_state=on_state)
+    await protocol.handle_client_message(
+        json.dumps({
+            "type": "hermes.input_audio.state",
+            "event_id": "mute-1",
+            "muted": True,
+        }),
+        "client-a",
+    )
+
+    assert states == [(True, "client-a")]
+    assert sent[-1][0]["type"] == "hermes.input_audio.state_updated"
+    assert sent[-1][0]["muted"] is True
+    assert sent[-1][1] == "client-a"
+
+
+@pytest.mark.asyncio
+async def test_rejects_invalid_input_audio_state() -> None:
+    protocol, sent = protocol_fixture(on_input_audio_state=lambda *_args: None)
+    await protocol.handle_client_message(
+        json.dumps({"type": "hermes.input_audio.state", "muted": "yes"}),
+        "client-a",
+    )
+
+    assert sent[-1][0]["error"]["code"] == "invalid_input_audio_state"
+
+
+@pytest.mark.asyncio
 async def test_targets_session_snapshot_and_correlated_client_error() -> None:
     protocol, sent = protocol_fixture()
 

--- a/tests/test_realtime_webrtc.py
+++ b/tests/test_realtime_webrtc.py
@@ -25,6 +25,7 @@ from hermes_livekit.realtime_webrtc import (
     PROXY_SIGNATURE_HEADER,
     PROXY_TIMESTAMP_HEADER,
     QueuedAudioTrack,
+    RealtimeCall,
     RealtimeWebRTCAdapter,
     _parse_ice_servers,
     _proxy_signature_payload,
@@ -417,3 +418,34 @@ async def test_direct_send_completes_transcript_response() -> None:
     protocol.assistant_transcript.assert_awaited_once_with("hello")
     protocol.output_stopped.assert_awaited_once_with()
     assert call.tts_completed is False
+
+
+@pytest.mark.asyncio
+async def test_direct_mute_finalizes_and_unmute_resets_vad() -> None:
+    protocol = AsyncMock()
+    adapter = SimpleNamespace(process_voice=AsyncMock())
+    call = RealtimeCall(
+        adapter=adapter,
+        call_id="call-a",
+        peer=AsyncMock(),
+        output_track=QueuedAudioTrack(),
+        protocol=protocol,
+    )
+    call.speaking = True
+    call.audio_buffer.extend(b"\x00\x00" * 48_000)
+    old_vad = call.vad
+
+    await call.set_input_audio_state(True)
+    await asyncio.sleep(0)
+    assert call.input_muted is True
+    assert call.audio_buffer == b""
+    protocol.speech_stopped.assert_awaited_once_with("webrtc-client")
+    adapter.process_voice.assert_awaited_once()
+
+    await call.set_input_audio_state(False)
+    assert call.input_muted is False
+    assert call.vad is not old_vad
+    assert call.vad.ready is False
+
+    for task in list(call.tasks):
+        task.cancel()


### PR DESCRIPTION
Adds an optional, namespaced `hermes.input_audio.state` event to both voice transports.

- Direct Realtime carries it on `oai-events`
- Conference carries the same envelope on `conference.extensions`
- mute finalizes the active participant utterance immediately
- unmute resets participant-scoped adaptive VAD calibration
- applies the shared adaptive RMS gate to Conference as well as direct WebRTC
- acknowledges state with `hermes.input_audio.state_updated`
- preserves fallback energy endpointing for clients that omit the extension

Validation: 166 tests pass in an isolated checkout on Snappy.