### PR TITLE
fix(realtime): suppress post-playback echo tail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,12 @@ of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follow
 - Removed private LiveKit FFI teardown now that the SDK owns remote-disconnect
   queue cleanup.
 
+### Fixed
+
+- Kept Direct Realtime capture suppressed for a short playout guard after TTS
+  leaves the server RTP queue, preventing the remote speaker/jitter-buffer tail
+  from being transcribed as a second user turn.
+
 ## [0.4.0] — 2026-07-28
 
 ### Added

--- a/hermes_livekit/realtime_webrtc.py
+++ b/hermes_livekit/realtime_webrtc.py
@@ -76,6 +76,10 @@ MAX_SDP_BYTES = 256 * 1024
 MAX_SESSION_BYTES = 512 * 1024
 DEFAULT_MAX_CALLS = 8
 DEFAULT_MAX_CALL_SECONDS = 2 * 60 * 60
+# Queued RTP frames have left the server when ``drained()`` returns, but the
+# remote jitter buffer and speaker can still be playing their tail.  Keep
+# capture suppressed briefly so that tail cannot become a new user turn.
+OUTPUT_ECHO_GUARD_SECONDS = 0.75
 PROXY_PRINCIPAL_HEADER = "X-Kortexa-Internal-Principal"
 PROXY_CALL_HEADER = "X-Kortexa-Internal-Call-Id"
 PROXY_TIMESTAMP_HEADER = "X-Kortexa-Internal-Timestamp"
@@ -861,6 +865,7 @@ class RealtimeWebRTCAdapter(BasePlatformAdapter):
             await call.protocol.output_started()
             await call.output_track.enqueue_pcm(pcm)
             await call.output_track.drained()
+            await asyncio.sleep(OUTPUT_ECHO_GUARD_SECONDS)
             await call.protocol.output_stopped()
             call.tts_completed = True
             return SendResult(success=True, message_id=uuid.uuid4().hex[:12])

--- a/tests/test_realtime_webrtc.py
+++ b/tests/test_realtime_webrtc.py
@@ -21,6 +21,7 @@ from gateway.platform_registry import PlatformEntry, platform_registry
 from hermes_livekit.realtime_webrtc import (
     AdaptiveRmsGate,
     CLIENT_IDENTITY,
+    OUTPUT_ECHO_GUARD_SECONDS,
     PROXY_CALL_HEADER,
     PROXY_PRINCIPAL_HEADER,
     PROXY_SIGNATURE_HEADER,
@@ -447,6 +448,46 @@ async def test_direct_send_voice_uses_native_audio_track() -> None:
         reply_to="message",
         metadata={"turn": 1},
     )
+
+
+@pytest.mark.asyncio
+async def test_direct_play_tts_keeps_capture_paused_for_output_echo_tail() -> None:
+    protocol = AsyncMock()
+    output_track = SimpleNamespace(enqueue_pcm=AsyncMock(), drained=AsyncMock())
+    call = SimpleNamespace(
+        protocol=protocol,
+        output_track=output_track,
+        paused=False,
+        tts_completed=False,
+    )
+    adapter = object.__new__(RealtimeWebRTCAdapter)
+    adapter._calls = {"call": call}
+
+    async def guarded_sleep(delay: float) -> None:
+        assert delay == OUTPUT_ECHO_GUARD_SECONDS
+        assert call.paused is True
+        protocol.output_stopped.assert_not_awaited()
+
+    with (
+        patch(
+            "hermes_livekit.adapter.LiveKitAdapter._decode_audio_to_pcm",
+            return_value=b"\x00\x00" * 320,
+        ),
+        patch(
+            "hermes_livekit.realtime_webrtc.asyncio.sleep",
+            side_effect=guarded_sleep,
+        ) as sleep,
+    ):
+        result = await adapter.play_tts("call", "reply.wav")
+
+    assert result.success is True
+    sleep.assert_awaited_once_with(OUTPUT_ECHO_GUARD_SECONDS)
+    output_track.enqueue_pcm.assert_awaited_once()
+    output_track.drained.assert_awaited_once_with()
+    protocol.output_started.assert_awaited_once_with()
+    protocol.output_stopped.assert_awaited_once_with()
+    assert call.tts_completed is True
+    assert call.paused is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Keeps Direct Realtime capture paused for 750 ms after queued TTS audio drains, covering client jitter-buffer and speaker playout tail so it cannot become a second user utterance. Includes a regression test; full suite: 172 passed.